### PR TITLE
Added encoding for '+' and '&'

### DIFF
--- a/programs/develop/libraries/http/http.asm
+++ b/programs/develop/libraries/http/http.asm
@@ -2022,7 +2022,7 @@ str_post        db 'POST ', 0
 
 bits_must_escape:
 dd      0xffffffff                                                      ; 00-1F
-dd      1 shl 0 + 1 shl 2 + 1 shl 3 + 1 shl 5 + 1 shl 28 + 1 shl 30     ; "#%<>
+dd      1 shl 0 + 1 shl 2 + 1 shl 3 + 1 shl 5 + 1 shl 6 + 1 shl 11 + 1 shl 28 + 1 shl 30     ; "#%<>+&"
 dd      1 shl 27 + 1 shl 28 + 1 shl 29 + 1 shl 30                       ;[\]^
 dd      1 shl 0 + 1 shl 27 + 1 shl 28 + 1 shl 29 + 1 shl 31             ;`{|} DEL
 


### PR DESCRIPTION
Addresses the issue: [#33](https://github.com/KolibriOS/kolibrios/issues/33).

Changes Made:
- Modified the encoding array in http.asm.
- Added 1 shl 6 for + and 1 shl 11 for & to the array.